### PR TITLE
PROBLEM: glad node name

### DIFF
--- a/include/glar_node.h
+++ b/include/glar_node.h
@@ -20,7 +20,7 @@ extern "C" {
 //  @interface
 //  Create a new glar_node
 GLAR_EXPORT glar_node_t *
-    glar_node_new (const char *iface, bool console, const char *node_name);
+    glar_node_new (const char *iface, bool console);
 
 //  Destroy the glar_node
 GLAR_EXPORT void

--- a/src/glar_node.c
+++ b/src/glar_node.c
@@ -81,7 +81,7 @@ s_button_actor (zsock_t *pipe, void *args)
 //  Create a new glar node
 
 glar_node_t *
-glar_node_new (const char *iface, bool console, const char *node_name)
+glar_node_new (const char *iface, bool console)
 {
     glar_node_t *self = (glar_node_t *) zmalloc (sizeof (glar_node_t));
     assert (self);
@@ -89,12 +89,10 @@ glar_node_new (const char *iface, bool console, const char *node_name)
 
     //  Grab us a new Zyre node
     self->zyre = zyre_new (NULL);
-    if (node_name == NULL)
-        node_name = zyre_name (self->zyre);
     zyre_set_interface (self->zyre, iface);
     zsys_info ("using interface=%s my_uuid=%s my_name=%s", iface,
             zyre_uuid (self->zyre),
-            node_name);
+            zyre_name (self->zyre));
 
     //  Start actors
     self->panel = zactor_new (glar_panel_actor, NULL);
@@ -423,7 +421,7 @@ glar_node_test (bool verbose)
     printf (" * glar_node: ");
 
     //  @selftest
-    glar_node_t *node = glar_node_new ("wlan0", false, NULL);
+    glar_node_t *node = glar_node_new ("wlan0", false);
     if (verbose)
         glar_node_set_verbose (node, verbose);
     assert (node);

--- a/src/glard.c
+++ b/src/glard.c
@@ -37,7 +37,6 @@ main (int argc, char *argv [])
     bool console = false;
     bool ipv6 = false;
     char *iface = "wlan0";
-    char *node_name = NULL;
 
     int argn;
     for (argn = 1; argn < argc; argn++) {
@@ -48,7 +47,6 @@ main (int argc, char *argv [])
             puts ("  --verbose / -v         verbose test output");
             puts ("  --interface / -i       use this interface");
             puts ("  --console / -c         remote control console");
-            puts ("  --name / -n MY_NAME    my node name (default: random)");
             puts ("  --ipv6 / -6            connect over IPv6");
             return 0;
         }
@@ -59,15 +57,6 @@ main (int argc, char *argv [])
         if (streq (argv [argn], "--console")
         ||  streq (argv [argn], "-c"))
             console = true;
-        else
-        if (streq (argv [argn], "--name")
-        ||  streq (argv [argn], "-n")) {
-            if (argn + 1 >= argc) {
-                zsys_error ("argument required for --name\n");
-                return -1;
-            }
-            node_name = argv [++argn];
-            }
         else
         if (streq (argv [argn], "--interface")
         ||  streq (argv [argn], "-i"))
@@ -82,7 +71,7 @@ main (int argc, char *argv [])
         }
     }
     zsys_set_ipv6(ipv6);
-    glar_node_t *node = glar_node_new (iface, console, node_name);
+    glar_node_t *node = glar_node_new (iface, console);
     glar_node_set_verbose (node, verbose);
     glar_node_execute (node);
     glar_node_destroy (&node);


### PR DESCRIPTION
It doesn't work - custom glard node name does not trasnfer across zyre.
Adding this possible technically, but a huge antipattern defeating
original purpose.
SOLUTION: Remove glar node name, it does not solve any problem

Signed-off-by: Karol Hrdina <KarolHrdina@Eaton.com>